### PR TITLE
remove auto for shared memory

### DIFF
--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -81,11 +81,11 @@ ALPAKA_FN_ACC void operator()(
     //\todo: testen ob es schneller ist, erst zu flushen wennn Source voll ist
     auto destFrames(alpaka::block::shared::allocArr<FRAME *, Exchanges>(acc));
     auto destFramesCounter(alpaka::block::shared::allocArr<int, Exchanges>(acc)); //count particles per frame
-    auto anyDestFrameFull(alpaka::block::shared::allocVar<bool>(acc)); //flag if any destination Frame is full
+    PMACC_AUTO(anyDestFrameFull,alpaka::block::shared::allocVar<bool>(acc)); //flag if any destination Frame is full
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isFrameValid(alpaka::block::shared::allocVar<bool>(acc));
-    auto mustShift(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isFrameValid,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(mustShift,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -283,14 +283,14 @@ ALPAKA_FN_ACC void operator()(
 
     DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
 
-    auto lastFrame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(lastFrame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     auto gapIndices_sh(alpaka::block::shared::allocArr<int, TileSize>(acc));
-    auto counterGaps(alpaka::block::shared::allocVar<int>(acc));
-    auto counterParticles(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(counterGaps,alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(counterParticles,alpaka::block::shared::allocVar<int>(acc));
 
-    auto srcGap(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(srcGap,alpaka::block::shared::allocVar<int>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -366,13 +366,13 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
 
     //data copied from right (last) to left (first)
-    auto firstFrame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto lastFrame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(firstFrame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(lastFrame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     auto particleIndices_sh(alpaka::block::shared::allocArr<int, TileSize>(acc));
-    auto counterGaps(alpaka::block::shared::allocVar<int>(acc));
-    auto counterParticles(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(counterGaps,alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(counterParticles,alpaka::block::shared::allocVar<int>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -494,8 +494,8 @@ ALPAKA_FN_ACC void operator()(
 
     const int linearThreadIdx = threadIdx.x();
 
-    auto frame(alpaka::block::shared::allocVar<FrameType *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FrameType *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialized*/
 
@@ -556,11 +556,11 @@ ALPAKA_FN_ACC void operator()(
 
     DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
 
-    auto numBashedParticles(alpaka::block::shared::allocVar<uint32_t>(acc));
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
-    auto hasMemory(alpaka::block::shared::allocVar<bool>(acc));
-    auto tmpBorder(alpaka::block::shared::allocVar<TileDataBox<BORDER>>(acc));
+    PMACC_AUTO(numBashedParticles,alpaka::block::shared::allocVar<uint32_t>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(hasMemory,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(tmpBorder,alpaka::block::shared::allocVar<TileDataBox<BORDER>>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -653,9 +653,9 @@ ALPAKA_FN_ACC void operator()(
 
     DataSpace<1> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto elementCount(alpaka::block::shared::allocVar<int>(acc));
-    auto tmpBorder(alpaka::block::shared::allocVar<TileDataBox<BORDER>>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(elementCount,alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(tmpBorder,alpaka::block::shared::allocVar<TileDataBox<BORDER>>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 

--- a/src/libPMacc/include/particles/operations/CountParticles.hpp
+++ b/src/libPMacc/include/particles/operations/CountParticles.hpp
@@ -55,10 +55,10 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
-    auto counter(alpaka::block::shared::allocVar<int>(acc));
-    auto particlesInSuperCell(alpaka::block::shared::allocVar<lcellId_t>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(counter,alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(particlesInSuperCell,alpaka::block::shared::allocVar<lcellId_t>(acc));
 
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialized*/

--- a/src/libPMacc/include/types.h
+++ b/src/libPMacc/include/types.h
@@ -36,8 +36,8 @@
 #include <stdint.h>
 #include <stdexcept>
 
-#define PMACC_AUTO_TPL(var,...) BOOST_AUTO_TPL(var,(__VA_ARGS__))
-#define PMACC_AUTO(var,...) BOOST_AUTO(var,(__VA_ARGS__))
+#define PMACC_AUTO_TPL(var,...) decltype(__VA_ARGS__) var(__VA_ARGS__)
+#define PMACC_AUTO(var,...) decltype(__VA_ARGS__) var(__VA_ARGS__)
 
 namespace PMacc
 {

--- a/src/picongpu/include/fields/FieldManipulator.kernel
+++ b/src/picongpu/include/fields/FieldManipulator.kernel
@@ -54,7 +54,7 @@ DINLINE void absorb(
     //cells in simulation
     const DataSpace<simDim> gCells = mapper.getGridSuperCells() * SuperCellSize::toRT();
 
-    auto finish(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(finish,alpaka::block::shared::allocVar<int>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 

--- a/src/picongpu/include/fields/FieldTmp.kernel
+++ b/src/picongpu/include/fields/FieldTmp.kernel
@@ -68,9 +68,9 @@ namespace picongpu
 
         const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > ( threadIndex );
 
-        auto frame(alpaka::block::shared::allocVar<typename ParBox::FrameType *>(acc));
-        auto isValid(alpaka::block::shared::allocVar<bool>(acc));
-        auto particlesInSuperCell(alpaka::block::shared::allocVar<lcellId_t>(acc));
+        PMACC_AUTO(frame,alpaka::block::shared::allocVar<typename ParBox::FrameType *>(acc));
+        PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
+        PMACC_AUTO(particlesInSuperCell,alpaka::block::shared::allocVar<lcellId_t>(acc));
 
         /* wait until all shared memory is initialised */
         alpaka::block::sync::syncBlockThreads(acc);

--- a/src/picongpu/include/particles/Particles.kernel
+++ b/src/picongpu/include/particles/Particles.kernel
@@ -72,9 +72,9 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto myFrame(alpaka::block::shared::allocVar<MYFRAME *>(acc));
-    auto frame(alpaka::block::shared::allocVar<OTHERFRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(myFrame,alpaka::block::shared::allocVar<MYFRAME *>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<OTHERFRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -138,8 +138,8 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<typename T_ParBox::FrameType*>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<typename T_ParBox::FrameType*>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -218,7 +218,7 @@ ALPAKA_FN_ACC void operator()(
 
     typename ParBox::FrameType *frame;
     bool isValid;
-    auto mustShift(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(mustShift,alpaka::block::shared::allocVar<int>(acc));
     lcellId_t particlesInSuperCell;
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/

--- a/src/picongpu/include/particles/ParticlesInit.kernel
+++ b/src/picongpu/include/particles/ParticlesInit.kernel
@@ -89,7 +89,7 @@ ALPAKA_FN_ACC void operator()(
 
     const DataSpace<simDim> superCells(mapper.getGridSuperCells());
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
@@ -112,7 +112,7 @@ ALPAKA_FN_ACC void operator()(
 
     const float_X realParticlesPerCell = realDensity * CELL_VOLUME;
 
-    auto finished(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(finished,alpaka::block::shared::allocVar<int>(acc));
     if (linearThreadIdx == 0)
         finished = 1;
     alpaka::block::sync::syncBlockThreads(acc);

--- a/src/picongpu/include/particles/access/Cell2Particle.tpp
+++ b/src/picongpu/include/particles/access/Cell2Particle.tpp
@@ -45,9 +45,9 @@ BOOST_PP_ENUM_TRAILING(N, NORMAL_ARGS, _)) \
                                threadIndex.y() * SuperCellSize::x::value + threadIndex.x(); \
     \
     typedef typename TParticlesBox::FrameType Frame; \
-    auto frame(alpaka::block::shared::allocVar<Frame*>(acc)); \
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc)); \
-    auto particlesInSuperCell(alpaka::block::shared::allocVar<uint16_t>(acc)); \
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<Frame*>(acc)); \
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc)); \
+    PMACC_AUTO(particlesInSuperCell,alpaka::block::shared::allocVar<uint16_t>(acc)); \
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/ \
     \
     if(linearThreadIdx == 0) \

--- a/src/picongpu/include/particles/ionization/ionization.hpp
+++ b/src/picongpu/include/particles/ionization/ionization.hpp
@@ -123,10 +123,10 @@ ALPAKA_FN_ACC void operator()(
 
     alpaka::block::sync::syncBlockThreads(acc);
 
-    auto ionFrame(alpaka::block::shared::allocVar<IONFRAME *>(acc));
-    auto electronFrame(alpaka::block::shared::allocVar<ELECTRONFRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
-    auto maxParticlesInFrame(alpaka::block::shared::allocVar<lcellId_t>(acc));
+    PMACC_AUTO(ionFrame,alpaka::block::shared::allocVar<IONFRAME *>(acc));
+    PMACC_AUTO(electronFrame,alpaka::block::shared::allocVar<ELECTRONFRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(maxParticlesInFrame,alpaka::block::shared::allocVar<lcellId_t>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialized*/
 
@@ -149,7 +149,7 @@ ALPAKA_FN_ACC void operator()(
     /* Declare counter in shared memory that will later tell the current fill level or
      * occupation of the newly created target electron frames.
      */
-    auto newFrameFillLvl(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(newFrameFillLvl,alpaka::block::shared::allocVar<int>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait until all shared memory is initialized*/
 

--- a/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/CreateParticlesFromParticleImpl.hpp
@@ -85,8 +85,8 @@ struct CreateParticlesFromParticleImpl : private T_Functor
 
         DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-        auto destFrame(alpaka::block::shared::allocVar<DestFrameType*>(acc));
-        auto particlesInDestSuperCell(alpaka::block::shared::allocVar<int>(acc));
+        PMACC_AUTO(destFrame,alpaka::block::shared::allocVar<DestFrameType*>(acc));
+        PMACC_AUTO(particlesInDestSuperCell,alpaka::block::shared::allocVar<int>(acc));
 
         alpaka::block::sync::syncBlockThreads(acc);
 

--- a/src/picongpu/include/plugins/BinEnergyParticles.hpp
+++ b/src/picongpu/include/plugins/BinEnergyParticles.hpp
@@ -76,9 +76,9 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
-    auto particlesInSuperCell(alpaka::block::shared::allocVar<lcellId_t>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(particlesInSuperCell,alpaka::block::shared::allocVar<lcellId_t>(acc));
 
     const bool enableDetector = maximumSlopeToDetectorX != float_X(0.0) && maximumSlopeToDetectorZ != float_X(0.0);
 

--- a/src/picongpu/include/plugins/EnergyParticles.hpp
+++ b/src/picongpu/include/plugins/EnergyParticles.hpp
@@ -68,10 +68,10 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));         /* pointer to particle data frame */
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));          /* is data frame valid? */
-    auto shEnergyKin(alpaka::block::shared::allocVar<float_X>(acc));   /* shared kinetic energy */
-    auto shEnergy(alpaka::block::shared::allocVar<float_X>(acc));      /* shared total energy */
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));         /* pointer to particle data frame */
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));          /* is data frame valid? */
+    PMACC_AUTO(shEnergyKin,alpaka::block::shared::allocVar<float_X>(acc));   /* shared kinetic energy */
+    PMACC_AUTO(shEnergy,alpaka::block::shared::allocVar<float_X>(acc));      /* shared total energy */
 
     alpaka::block::sync::syncBlockThreads(acc); /* wait that all shared memory is initialised */
 

--- a/src/picongpu/include/plugins/PositionsParticles.hpp
+++ b/src/picongpu/include/plugins/PositionsParticles.hpp
@@ -112,8 +112,8 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 

--- a/src/picongpu/include/plugins/SumCurrents.hpp
+++ b/src/picongpu/include/plugins/SumCurrents.hpp
@@ -61,7 +61,7 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto sh_sumJ(alpaka::block::shared::allocVar<float3_X>(acc));
+    PMACC_AUTO(sh_sumJ,alpaka::block::shared::allocVar<float3_X>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 

--- a/src/picongpu/include/plugins/kernel/CopySpecies.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpecies.kernel
@@ -178,13 +178,13 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto srcFramePtr(alpaka::block::shared::allocVar<SrcFrameType *>(acc));
-    auto localCounter(alpaka::block::shared::allocVar<int>(acc));
-    auto globalOffset(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(srcFramePtr,alpaka::block::shared::allocVar<SrcFrameType *>(acc));
+    PMACC_AUTO(localCounter,alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(globalOffset,alpaka::block::shared::allocVar<int>(acc));
 
     int storageOffset;
 
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 

--- a/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
+++ b/src/picongpu/include/plugins/kernel/CopySpeciesGlobal2Local.kernel
@@ -74,7 +74,7 @@ ALPAKA_FN_ACC void operator()(
 
     auto destFramePtr(alpaka::block::shared::allocArr<DestFramePtr, cellsInSuperCell>(acc));
     auto linearSuperCellIds(alpaka::block::shared::allocArr<int, cellsInSuperCell>(acc));
-    auto hdf5ParticleOffset(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(hdf5ParticleOffset,alpaka::block::shared::allocVar<int>(acc));
 
 
     const int linearThreadIdx = threadIndex.x();

--- a/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/src/picongpu/include/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -69,9 +69,9 @@ ALPAKA_FN_ACC void operator()(
 
     const int linearThreadIdx = DataSpaceOperations<simDim>::template map<SuperCellSize > (threadIndex);
 
-    auto counterValue(alpaka::block::shared::allocVar<uint64_cu>(acc));
-    auto frame(alpaka::block::shared::allocVar<FrameType *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(counterValue,alpaka::block::shared::allocVar<uint64_cu>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FrameType *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
 
     if (linearThreadIdx == 0)
     {

--- a/src/picongpu/include/plugins/output/images/Visualisation.hpp
+++ b/src/picongpu/include/plugins/output/images/Visualisation.hpp
@@ -301,8 +301,8 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc));
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc));
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
     bool isImageThread = false;
 

--- a/src/picongpu/include/plugins/radiation/Radiation.kernel
+++ b/src/picongpu/include/plugins/radiation/Radiation.kernel
@@ -117,9 +117,9 @@ ALPAKA_FN_ACC void operator()(
     DataSpace<simDim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<simDim> const threadIndex(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    auto frame(alpaka::block::shared::allocVar<FRAME *>(acc)); // pointer to  frame storing particles
-    auto isValid(alpaka::block::shared::allocVar<bool>(acc)); // bool saying if frame is valid
-    auto particlesInFrame(alpaka::block::shared::allocVar<lcellId_t>(acc)); // number  of particles in current frame
+    PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc)); // pointer to  frame storing particles
+    PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc)); // bool saying if frame is valid
+    PMACC_AUTO(particlesInFrame,alpaka::block::shared::allocVar<lcellId_t>(acc)); // number  of particles in current frame
 
     using namespace parameters; // parameters of radiation
 
@@ -149,7 +149,7 @@ ALPAKA_FN_ACC void operator()(
 
     // particle counter used if not all particles are considered for
     // radiation calculation
-    auto counter_s(alpaka::block::shared::allocVar<int>(acc));
+    PMACC_AUTO(counter_s,alpaka::block::shared::allocVar<int>(acc));
 
     // memory for Nyquist frequency at current time step
 #if (__NYQUISTCHECK__==1)


### PR DESCRIPTION
- change PMACC_AUTO implementation
- use PMACC_AUTO for alpaka shared memory `alpaka::block::shared::allocVar<>`

This solves a problem that was found by @erikzenker that `auto ...` make a copy and can not held references.
see: http://stackoverflow.com/questions/8797800/auto-from-const-stdvector-object-or-reference

Solution:
- use `decltype( COMMAND ) varname(COMMAND);` (implemented in this pull request)
- use `auto&& varname(COMMAND);` ( suggestion from @BenjaminW3  / found http://stackoverflow.com/questions/13230480/what-does-auto-tell-us)
