### PR TITLE
rename `blockIdx` to `blockIndex`

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -81,9 +81,9 @@ namespace gol
                 // Calculate indices.
 
                 // Get the block index.
-                PMacc::DataSpace<DIM2> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+                PMacc::DataSpace<DIM2> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
                 // Get the SuperCell index relative to the whole grid in units of SuperCells. A block corresponds directly to one SuperCell but the mapping can be arbitrary.
-                PMacc::DataSpace<DIM2> const gridSuperCellIdxSC(mapper.getSuperCellIndex(blockIdx));
+                PMacc::DataSpace<DIM2> const gridSuperCellIdxSC(mapper.getSuperCellIndex(blockIndex));
                 // Get the SuperCell index relative to the whole grid in unit of cells.
                 PMacc::DataSpace<DIM2> const gridSuperCellIdxC(gridSuperCellIdxSC * Mapping::SuperCellSize::toRT());
                 // Get the cell index relative to the super cell.
@@ -165,9 +165,9 @@ namespace gol
                 // Calculate indices.
 
                 // Get the block index.
-                PMacc::DataSpace<DIM2> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+                PMacc::DataSpace<DIM2> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
                 // Get the SuperCell index relative to the whole grid in units of SuperCells. A block corresponds directly to one SuperCell but the mapping can be arbitrary.
-                PMacc::DataSpace<DIM2> const gridSuperCellIdxSC(mapper.getSuperCellIndex(blockIdx));
+                PMacc::DataSpace<DIM2> const gridSuperCellIdxSC(mapper.getSuperCellIndex(blockIndex));
                 // Get the SuperCell index in unit of cells.
                 PMacc::DataSpace<DIM2> const gridSuperCellIdxC(gridSuperCellIdxSC * Mapping::SuperCellSize::toRT());
                 // Get the cell index relative to the super cell.

--- a/src/libPMacc/include/particles/ParticlesBase.kernel
+++ b/src/libPMacc/include/particles/ParticlesBase.kernel
@@ -75,7 +75,7 @@ ALPAKA_FN_ACC void operator()(
         Exchanges = traits::NumberOfExchanges<Dim>::value
     };
 
-    DataSpace<Dim> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+    DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
     //\todo: testen ob es schneller ist, erst zu flushen wennn Source voll ist
@@ -89,7 +89,7 @@ ALPAKA_FN_ACC void operator()(
 
     alpaka::block::sync::syncBlockThreads(acc); /*wait that all shared memory is initialised*/
 
-    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIndex)));
 
     if (threadIdx.x() == 0)
     {
@@ -278,10 +278,10 @@ ALPAKA_FN_ACC void operator()(
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+    DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIndex)));
 
     PMACC_AUTO(lastFrame,alpaka::block::shared::allocVar<FRAME *>(acc));
     PMACC_AUTO(isValid,alpaka::block::shared::allocVar<bool>(acc));
@@ -360,10 +360,10 @@ ALPAKA_FN_ACC void operator()(
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+    DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIndex)));
 
     //data copied from right (last) to left (first)
     PMACC_AUTO(firstFrame,alpaka::block::shared::allocVar<FRAME *>(acc));
@@ -487,10 +487,10 @@ ALPAKA_FN_ACC void operator()(
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+    DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIndex)));
 
     const int linearThreadIdx = threadIdx.x();
 
@@ -551,10 +551,10 @@ ALPAKA_FN_ACC void operator()(
         Dim = Mapping::Dim
     };
 
-    DataSpace<Dim> const blockIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
+    DataSpace<Dim> const blockIndex(alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc));
     DataSpace<Dim> const threadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
 
-    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIdx)));
+    DataSpace<Dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<Dim > (blockIndex)));
 
     PMACC_AUTO(numBashedParticles,alpaka::block::shared::allocVar<uint32_t>(acc));
     PMACC_AUTO(frame,alpaka::block::shared::allocVar<FRAME *>(acc));


### PR DESCRIPTION
rename `blockIdx` that it not collide with cuda predefined variable names
