### PR TITLE
Const to constexpr in laserwakefield example

### DIFF
--- a/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
+++ b/examples/LaserWakefield/include/simulation_defines/param/gasConfig.param
@@ -34,7 +34,7 @@ namespace SI
  *
  * He (2e- / Atom ) with 1.e15 He / m^3
  *                      = 2.e15 e- / m^3 */
-const double GAS_DENSITY_SI = 1.e25;
+static constexpr double GAS_DENSITY_SI = 1.e25;
 
 }
 


### PR DESCRIPTION
Got an compile error in physicalConstants.unitless in line 37 because `SI::GAS_DENSITY_SI`
is not a `constexpr`:

```
 static constexpr float_64  GAS_DENSITY_NORMED= SI::GAS_DENSITY_SI;
```

I think the problem occurs because I compile locally with gcc 5.2.0 and older gcc
versions do not enforce constexpr.

But a general advice: We should move all compile time constants from const to constexpr
in the future.
