### PR TITLE
use vector for threadElemExtent

### DIFF
--- a/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
+++ b/src/libPMacc/include/eventSystem/events/kernelEvents.hpp
@@ -86,5 +86,9 @@
     {\
         PMACC_KERNEL_CATCH(::alpaka::wait::wait(::PMacc::Environment<>::get().DeviceManager().getAccDevice()), "__cudaKernel: crash before kernel call");\
         ::PMacc::TaskKernel * const taskKernel(::PMacc::Environment<>::get().Factory().createTaskKernel(#KERNEL));\
-        auto const exec(::alpaka::exec::create<::PMacc::AlpakaAcc<DIM>>(::alpaka::workdiv::WorkDivMembers<DIM, ::PMacc::AlpakaIdxSize>(__VA_ARGS__,static_cast<AlpakaIdxSize>(1u)), KERNEL\
+        auto const exec(::alpaka::exec::create<::PMacc::AlpakaAcc<DIM>>(       \
+            ::alpaka::workdiv::WorkDivMembers<DIM, ::PMacc::AlpakaIdxSize>(    \
+                __VA_ARGS__,                                                   \
+                ::PMacc::math::Vector<::PMacc::AlpakaIdxSize,DIM::value>::create(1u)  \
+            ), KERNEL                                                          \
         PMACC_KERNEL_PARAMS

--- a/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/TaskSetValue.hpp
@@ -202,7 +202,7 @@ public:
         alpaka::workdiv::WorkDivMembers<alpaka::dim::DimInt<dim>, AlpakaIdxSize> workDiv(
             gridSize,
             blockSize,
-            static_cast<AlpakaIdxSize>(1u));
+            ::PMacc::math::Vector<::PMacc::AlpakaIdxSize,dim>::create(1u));
         auto const exec(
             alpaka::exec::create<AlpakaAcc<alpaka::dim::DimInt<dim>>>(
                 workDiv,
@@ -275,7 +275,7 @@ public:
         alpaka::workdiv::WorkDivMembers<alpaka::dim::DimInt<dim>, AlpakaIdxSize> workDiv(
             gridSize,
             blockSize,
-            static_cast<AlpakaIdxSize>(1u));
+            ::PMacc::math::Vector<::PMacc::AlpakaIdxSize,dim>::create(1u));
         auto const exec(
             alpaka::exec::create<AlpakaAcc<alpaka::dim::DimInt<dim>>>(
                 workDiv,

--- a/src/picongpu/include/simulation_classTypes.hpp
+++ b/src/picongpu/include/simulation_classTypes.hpp
@@ -70,7 +70,13 @@ namespace picongpu
 #define __picKernelArea(KERNEL, DIM, description, area, block)\
     {\
         PMACC_KERNEL_CATCH(::alpaka::wait::wait(::PMacc::Environment<>::get().DeviceManager().getAccDevice()), "picKernelArea: crash before kernel call");\
-        ::PMacc::AreaMapping<area, MappingDesc> mapper(description);\
+        typedef ::PMacc::AreaMapping<area, MappingDesc> UsedAreaMapper;              \
+        UsedAreaMapper mapper(description);                                          \
         ::PMacc::TaskKernel * const taskKernel(::PMacc::Environment<>::get().Factory().createTaskKernel(#KERNEL));\
-        auto const exec(::alpaka::exec::create<::PMacc::AlpakaAcc<DIM>>(::alpaka::workdiv::WorkDivMembers<DIM, AlpakaIdxSize>(mapper.getGridDim(),block,static_cast<AlpakaIdxSize>(1u)), KERNEL\
+        auto const exec(::alpaka::exec::create<::PMacc::AlpakaAcc<DIM>>(             \
+            ::alpaka::workdiv::WorkDivMembers<DIM, AlpakaIdxSize>(                   \
+                mapper.getGridDim(),                                                 \
+                block,                                                               \
+                ::PMacc::math::Vector<AlpakaIdxSize,UsedAreaMapper::Dim>::create(1u) \
+            ), KERNEL                                                                \
         PIC_KERNEL_PARAMS


### PR DESCRIPTION
remove scalar with vector in `WorkDivMembers(...,threadElemExtent)`

This pull request removes conversion warning if accelerator  device is set to cuda.
