### PR TITLE
fix error/warning with c++11

### DIFF
--- a/thirdParty/cuda_memtest/cuda_memtest.h
+++ b/thirdParty/cuda_memtest/cuda_memtest.h
@@ -80,12 +80,12 @@ extern void get_driver_info(char* info, unsigned int len);
 #define PRINTF(fmt,...) do{						\
 	if (monitor_temp){						\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    printf("[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);				\
 	}								\
 	else{								\
 	    pthread_mutex_lock(&mutex);					\
-	    printf("[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    printf("[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	    pthread_mutex_unlock(&mutex);					\
 	}								\
 	fflush(stdout);							\
@@ -94,10 +94,10 @@ extern void get_driver_info(char* info, unsigned int len);
 
 #define FPRINTF(fmt,...) do{						\
 	if (monitor_temp){					\
-	    fprintf(stderr, "[%s][%s][%d][%d C]:"fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d][%d C]:" fmt, time_string(), hostname, gpu_idx, gpu_temp[gpu_idx],##__VA_ARGS__); \
 	}								\
 	else{								\
-	    fprintf(stderr, "[%s][%s][%d]:"fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
+	    fprintf(stderr, "[%s][%s][%d]:" fmt, time_string(), hostname, gpu_idx, ##__VA_ARGS__); \
 	}								\
 	fflush(stderr);							\
     } while(0)

--- a/thirdParty/cuda_memtest/ocl_tests.h
+++ b/thirdParty/cuda_memtest/ocl_tests.h
@@ -6,7 +6,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
+
 #define TYPE unsigned long
 #define MAX_ERR_RECORD_COUNT 10
 #define MAX_NUM_DEVICES 16
@@ -18,7 +18,7 @@ extern "C" {
 #define BLOCKSIZE ((unsigned long)(1024*1024))
 
   char* print_cl_errstring(cl_int err);
-  
+
 #define TDIFF(tb, ta) (tb.tv_sec - ta.tv_sec + 0.000001*(tb.tv_usec - ta.tv_usec))
 
 #define RECORD_ERR(err, p, expect, current) do{         \
@@ -29,19 +29,19 @@ extern "C" {
     err_current[idx] = (unsigned long)current;		\
     err_second_read[idx] = (unsigned long)(*p);		\
   }while(0)
-  
+
 #define PRINTF(fmt,...) do{                                             \
     pthread_mutex_lock(&mutex);						\
-    printf("[%s][%s][%d]:"fmt, time_string(), hostname, mc->device_idx, ##__VA_ARGS__); \
+    printf("[%s][%s][%d]:" fmt, time_string(), hostname, mc->device_idx, ##__VA_ARGS__); \
     fflush(stdout);							\
     pthread_mutex_unlock(&mutex);                                       \
   } while(0)
 
 
-  
+
 #define ERR_BAD_STATE  -1
 #define ERR_GENERAL -999
-  
+
 #define CLERR if (rc != CL_SUCCESS){					\
     printf("ERROR: opencl call failed with rc(%d), line %d, file %s\n", rc, __LINE__, __FILE__); \
     printf("Error: %s\n", print_cl_errstring(rc));			\
@@ -49,7 +49,7 @@ extern "C" {
   }
 
 #define DIM(x) (sizeof(x)/sizeof(x[0]))
-  
+
   typedef struct memtest_control_s{
     cl_context context;
     cl_uint device_idx;
@@ -65,13 +65,13 @@ extern "C" {
     cl_program program;
     cl_event events[MAX_NUM_KERNELS];
   }memtest_control_t;
-  
+
   void test10(memtest_control_t*);
   void* run_tests(void* arg);
 
-  
+
   typedef  void (*test_func_t)(memtest_control_t*);
-  
+
   typedef struct cuda_memtest_s{
     test_func_t func;
     const char* desc;
@@ -79,7 +79,7 @@ extern "C" {
   }cuda_memtest_t;
 
 
-  
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- WARNING: a user-provided literal suffix must begin with "_"
- warning results in ERROR: user-defined literal operator not found

This is a change in `thirdParty` what is forbidden by PIConGPU commit rules but thus we are in the piconalpaka dev branch we can accept it. I also push this fix to the `cuda_memtest` repo.

Note: the end of line white spaces are removed automatically by my IDE

Original errors:

```
/bigdata/hplsim/scratch/widera/dev/thirdParty/cuda_memtest/cuda_memtest.cu(94): warning: a user-provided literal suffix must begin with "_"

/bigdata/hplsim/scratch/widera/dev/thirdParty/cuda_memtest/cuda_memtest.cu(94): error: user-defined literal operator not found
```
