### PR TITLE
fix nvcc compile error with boost

### DIFF
--- a/src/libPMacc/PMaccConfig.cmake
+++ b/src/libPMacc/PMaccConfig.cmake
@@ -125,6 +125,27 @@ ELSE()
     LIST(APPEND _PMACC_INCLUDE_DIRECTORIES_PUBLIC ${Boost_INCLUDE_DIRS})
 ENDIF()
 
+# PMacc (ab)uses boost::result_of for non-functors (e.g. []-operators). This
+# define forces boost to use the result<> member template of the target type
+if(Boost_VERSION LESS 105500)
+    add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+else()
+    # Boost 1.55 adds support for another define that makes result_of look for
+    # the result<> template and falls back to decltype if none is found. This is
+    # great for the transition from the "wrong" usage to the "correct" one as
+    # both can be used. But:
+    # 1) Cannot be used in 7.0 due to nvcc bug:
+    #    http://stackoverflow.com/questions/31940457/
+    # 2) Requires C++11 enabled as there is no further check in boost besides
+    #    the version check of nvcc
+    if( (NOT CUDA_VERSION VERSION_EQUAL 7.0) AND (CMAKE_CXX_STANDARD EQUAL 11) )
+        add_definitions(-DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK)
+    else()
+        # Fallback
+        add_definitions(-DBOOST_RESULT_OF_USE_TR1)
+    endif()
+endif()
+
 #-------------------------------------------------------------------------------
 # Find mallocMC
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- fix nvcc compile bug with boost and result_of in c++11
- the problem and solution was descriped [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/1151)

This is a copy past of the solution implemented by @Flamefire and is automatically removed after the next rebase against the upstream dev branch of PIConGPU.
